### PR TITLE
FIX: missing th:text references in templates and properties

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -2,6 +2,10 @@ home.title = Video Shop
 home.welcome = Welcome to our Videoshop.
 home.logout = Logout
 
+login.username = Username
+login.password = Password
+login.login = Login
+
 nav.home = Home
 nav.dvdCatalog = DVD Catalog
 nav.blurayCatalog = BluRay Catalog
@@ -19,6 +23,7 @@ register.name = Name
 register.password = Password
 register.address = Address
 register.submit= register
+register.userdata = User data
 
 catalog.title = Title
 catalog.dvd.title = DVD Catalog

--- a/src/main/resources/messages_de.properties
+++ b/src/main/resources/messages_de.properties
@@ -2,6 +2,10 @@ home.title = Video Shop
 home.welcome = Willkommen zu unserem Videoshop.
 home.logout = Logout
 
+login.username = Benutzername
+login.password = Passwort
+login.login = Einloggen
+
 nav.home = Home
 nav.dvdCatalog = DVD Katalog
 nav.blurayCatalog = BluRay Katalog
@@ -19,6 +23,7 @@ register.name = Name
 register.password = Passwort
 register.address = Adresse
 register.submit= Registrieren
+register.userdata = Nutzerdaten
 
 catalog.title = Titel
 catalog.dvd.title = DVD Katalog

--- a/src/main/resources/templates/detail.html
+++ b/src/main/resources/templates/detail.html
@@ -44,7 +44,7 @@
                             <input id="number" type="number" name="number" min="1" max="5" step="1" value="1"/><br/>
                         </div>
                         <button type="submit" class="ui labeled icon button">
-                            <i class="add to cart icon"></i> Hinzufügen
+                            <i class="add to cart icon"></i><span th:text="#{detail.addToBasket}"> Hinzufügen</span>
                         </button>
                     </form>
                 </div>
@@ -53,7 +53,7 @@
     </div>
 
     <div class="ui comments">
-        <h3 class="ui dividing header">Kommentare</h3>
+        <h3 class="ui dividing header" th:text="#{detail.comment.comments}">Kommentare</h3>
 
         <div class="comment" th:each="comment : ${disc.comments}">
             <div class="content">
@@ -72,11 +72,11 @@
                 <textarea id="comment" name="comment" cols="40" rows="5"></textarea><br/>
             </div>
             <div class="field">
-                <label for="rating">Bewertung</label>
+                <label th:text="#{detail.comment.rating}" for="rating">Bewertung</label>
                 <input id="rating" name="rating" type="number" value="5" />
             </div>
             <button type="submit" class="ui labeled icon button">
-                <i class="icon edit"></i> Kommentieren
+                <i class="icon edit"></i><span th:text="#{detail.comment.addComment}"> Kommentieren</span>
             </button>
         </form>
     </div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -25,16 +25,16 @@
     <form class="ui form" role="form" th:action="@{/login}" method="post">
 
         <div class="field">
-            <label for="username">Username</label>
+            <label th:text="#{login.username}" for="username">Username</label>
             <input type="text" id="username" name="username" autofocus="autofocus"/> <br/>
         </div>
 
         <div class="field">
-            <label for="password">Password</label>
+            <label th:text="#{login.password}" for="password">Password</label>
             <input type="password" id="password" name="password"/> <br/>
         </div>
 
-        <button type="submit" class="ui button">Log in</button>
+        <button type="submit" th:text="#{login.login}" class="ui button">Log in</button>
     </form>
 </div>
 </body>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -24,7 +24,7 @@
 
     <form method="post" role="form" class="ui form" id="form" th:action="@{/register}" th:object="${form}">
 
-        <h3 class="ui dividing header">Nutzerdaten</h3>
+        <h3 class="ui dividing header" th:text="#{register.userdata}">Nutzerdaten</h3>
 
         <div class="ui negative message" th:if="${#fields.hasErrors('*')}">
             <p>Einige Angaben sind nicht korrekt.</p>


### PR DESCRIPTION
Some html templates has missing th:text references, the application shows german text placeholders even on english-configurated browsers