### PR TITLE
Test ci and jqa profiles in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ jdk:
 
 sudo: false
 
-install: mvn dependency:list -Dsort -U
+install: mvn dependency:list -Dsort -B -U -V
+
+script:
+  - mvn verify -Pci -B -U
+  - mvn verify -Pjqa -B -U
 
 cache:
   directories:
     - $HOME/.m2
+

--- a/src/main/java/videoshop/catalog/VideoCatalog.java
+++ b/src/main/java/videoshop/catalog/VideoCatalog.java
@@ -35,16 +35,15 @@ public interface VideoCatalog extends Catalog<Disc> {
 	 * 
 	 * @param type must not be {@literal null}.
 	 * @param sort must not be {@literal null}.
-	 * @return
+	 * @return the discs of the given type, never {@literal null}.
 	 */
 	Iterable<Disc> findByType(DiscType type, Sort sort);
 
 	/**
-	 * Returns all {@link Disc}s by type ordered their identifier.
+	 * Returns all {@link Disc}s by type ordered by their identifier.
 	 * 
 	 * @param type must not be {@literal null}.
-	 * @param sort must not be {@literal null}.
-	 * @return
+	 * @return the discs of the given type, never {@literal null}.
 	 */
 	default Iterable<Disc> findByType(DiscType type) {
 		return findByType(type, DEFAULT_SORT);

--- a/src/main/java/videoshop/customer/CustomerDataInitializer.java
+++ b/src/main/java/videoshop/customer/CustomerDataInitializer.java
@@ -38,8 +38,11 @@ class CustomerDataInitializer implements DataInitializer {
 	private final CustomerRepository customerRepository;
 
 	/**
-	 * @param userAccountManager
-	 * @param customerRepository
+	 * Creates a new {@link CustomerDataInitializer} with the given
+	 * {@link UserAccountManager} and {@link CustomerRepository}.
+	 * 
+	 * @param userAccountManager must not be {@literal null}.
+	 * @param customerRepository must not be {@literal null}.
 	 */
 	CustomerDataInitializer(UserAccountManager userAccountManager, CustomerRepository customerRepository) {
 

--- a/src/main/java/videoshop/customer/CustomerManagement.java
+++ b/src/main/java/videoshop/customer/CustomerManagement.java
@@ -34,7 +34,10 @@ public class CustomerManagement {
 	private final UserAccountManager userAccounts;
 
 	/**
-	 * @param customers must not be {@literal null}.
+	 * Creates a new {@link CustomerManagement} with the given
+	 * {@link CustomerRepository} and {@link UserAccountManager}.
+	 * 
+	 * @param customers    must not be {@literal null}.
 	 * @param userAccounts must not be {@literal null}.
 	 */
 	CustomerManagement(CustomerRepository customers, UserAccountManager userAccounts) {
@@ -50,7 +53,7 @@ public class CustomerManagement {
 	 * Creates a new {@link Customer} using the information given in the {@link RegistrationForm}.
 	 * 
 	 * @param form must not be {@literal null}.
-	 * @return
+	 * @return the new {@link Customer} instance.
 	 */
 	public Customer createCustomer(RegistrationForm form) {
 
@@ -64,7 +67,7 @@ public class CustomerManagement {
 	/**
 	 * Returns all {@link Customer}s currently available in the system.
 	 * 
-	 * @return
+	 * @return all {@link Customer} entities.
 	 */
 	public Streamable<Customer> findAll() {
 		return Streamable.of(customers.findAll());

--- a/src/main/java/videoshop/inventory/InventoryController.java
+++ b/src/main/java/videoshop/inventory/InventoryController.java
@@ -37,7 +37,7 @@ class InventoryController {
 	 * Displays all {@link InventoryItem}s in the system
 	 * 
 	 * @param model will never be {@literal null}.
-	 * @return
+	 * @return the view name.
 	 */
 	@GetMapping("/stock")
 	@PreAuthorize("hasRole('ROLE_BOSS')")

--- a/src/main/java/videoshop/order/OrderController.java
+++ b/src/main/java/videoshop/order/OrderController.java
@@ -77,15 +77,14 @@ class OrderController {
 
 	/**
 	 * Adds a {@link Disc} to the {@link Cart}. Note how the type of the parameter taking the request parameter
-	 * {@code pid} is {@link Disc}. For all domain types extening {@link AbstractEntity} (directly or indirectly) a tiny
+	 * {@code pid} is {@link Disc}. For all domain types extending {@link AbstractEntity} (directly or indirectly) a tiny
 	 * Salespoint extension will directly load the object instance from the database. If the identifier provided is
 	 * invalid (invalid format or no {@link Product} with the id found), {@literal null} will be handed into the method.
 	 * 
-	 * @param disc
-	 * @param number
-	 * @param session
-	 * @param modelMap
-	 * @return
+	 * @param disc the disc that should be added to the cart (may be {@literal null}).
+	 * @param number number of discs that should be added to the cart.
+	 * @param cart must not be {@literal null}.
+	 * @return the view name.
 	 */
 	@PostMapping("/cart")
 	String addDisc(@RequestParam("pid") Disc disc, @RequestParam("number") int number, @ModelAttribute Cart cart) {
@@ -121,7 +120,7 @@ class OrderController {
 	 * 
 	 * @param cart will never be {@literal null}.
 	 * @param userAccount will never be {@literal null}.
-	 * @return
+	 * @return the view name.
 	 */
 	@PostMapping("/checkout")
 	String buy(@ModelAttribute Cart cart, @LoggedIn Optional<UserAccount> userAccount) {


### PR DESCRIPTION
This PR addresses the following issues:

- [x] Test the `ci` and `jqa` Maven profiles in Travis builds
- [x] Fixes Javadoc comment errors found by executing builds using the `ci` profile
- [x] Fixes an artifact resolution problem for `de.tudresden.inf.st.lab:st-lab-resources:jar:2.0.0.RELEASE` found be using the `ci` profile (depends on the fix in st-tu-dresden/st-lab#38 and a corresponding new release of the parent pom).