### PR TITLE
Fix für Registrierungsvalidation

### DIFF
--- a/src/main/java/videoshop/customer/CustomerController.java
+++ b/src/main/java/videoshop/customer/CustomerController.java
@@ -58,7 +58,7 @@ class CustomerController {
 
 	@GetMapping("/register")
 	String register(Model model, RegistrationForm form) {
-		model.addAttribute("form", form);
+		model.addAttribute("registrationForm", form);
 		return "register";
 	}
 

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -22,17 +22,17 @@
     </header>
     <nav th:include="navigation :: navigation"></nav>
 
-    <form method="post" role="form" class="ui form" id="form" th:action="@{/register}" th:object="${form}">
+    <form method="post" role="form" class="ui form" id="form" th:action="@{/register}" th:object="${registrationForm}">
 
         <h3 class="ui dividing header" th:text="#{register.userdata}">Nutzerdaten</h3>
 
-        <div class="ui negative message" th:if="${#fields.hasErrors('*')}">
+        <div class="ui negative message" th:if="${#fields.hasErrors('all')}">
             <p>Einige Angaben sind nicht korrekt.</p>
         </div>
 
         <div class="field">
             <label for="name">Name</label>
-            <input id="name" name="name" th:field="*{name}" th:errorclass="fieldError" type="text" required="required"/><br/>
+            <input id="name" name="name" th:field="*{name}" th:errorclass="fieldError" type="text"/><br/>
             <div class="ui negative message" th:if="${#fields.hasErrors('name')}" th:errors="*{name}">
                 <p>Der Name darf nicht leer sein.</p>
             </div>
@@ -40,17 +40,17 @@
 
         <div class="field">
             <label th:text="#{register.password}" for="password">Passwort</label>
-            <input id="password" name="password" th:field="*{password}" th:errorclass="fieldError" type="text"
-                   required="required"/><br/>
-            <p th:if="${#fields.hasErrors('password')}" th:errors="*{password}">Das Passwort darf
-                nicht leer sein.</p>
+            <input id="password" name="password" th:field="*{password}" th:errorclass="fieldError" type="text"/><br/>
+            <div class="ui negative message" th:if="${#fields.hasErrors('password')}" th:errors="*{password}">
+                <p>Das Passwort darf nicht leer sein.</p>
+            </div>
         </div>
         <div class="field">
             <label th:text="#{register.address}" for="address">Straße</label>
-            <input id="address" name="address" th:field="*{address}" th:errorclass="fieldError" type="text"
-                   required="required"/><br/>
-            <p th:if="${#fields.hasErrors('address')}" th:errors="*{address}">Die Adresse darf
-                nicht leer sein.</p>
+            <input id="address" name="address" th:field="*{address}" th:errorclass="fieldError" type="text"/><br/>
+            <div class="ui negative message" th:if="${#fields.hasErrors('address')}" th:errors="*{address}">
+                <p>Die Adresse darf nicht leer sein.</p>
+            </div>
         </div>
 
         <button type="submit" class="ui button" th:text="#{register.submit}">Registrieren</button>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -26,7 +26,7 @@
 
         <h3 class="ui dividing header" th:text="#{register.userdata}">Nutzerdaten</h3>
 
-        <div class="ui negative message" th:if="${#fields.hasErrors('all')}">
+        <div class="ui negative message" th:if="${#fields.hasErrors('*')}">
             <p>Einige Angaben sind nicht korrekt.</p>
         </div>
 


### PR DESCRIPTION
Technikamateur hat sich ja bereits an einem Fix für das Problem versucht (#92). 
Ich denke auch, dass es besser wäre hier die Validation zu benutzen, anstatt des 'required' tags. Die Validation ist ja zum größten Teil bereits implementiert, allerdings ist das Entfernen des 'required' tags nicht genug, um die Validation vorzunehmen.
Es scheint so, als hätte thymeleaf ein Problem damit, dass die forms durch ${form} referenziert werden, deshalb habe ich einfach den Namen geändert, was das Problem gelöst hat.

Viele Grüße