### PR TITLE
Make comment and rating required

### DIFF
--- a/src/main/resources/templates/detail.html
+++ b/src/main/resources/templates/detail.html
@@ -73,7 +73,7 @@
             </div>
             <div class="field">
                 <label th:text="#{detail.comment.rating}" for="rating">Bewertung</label>
-                <input id="rating" name="rating" type="number" value="5" required="required" />
+                <input id="rating" name="rating" type="number" value="5" required="required" min="1" max="5" />
             </div>
             <button type="submit" class="ui labeled icon button">
                 <i class="icon edit"></i><span th:text="#{detail.comment.addComment}"> Kommentieren</span>

--- a/src/main/resources/templates/detail.html
+++ b/src/main/resources/templates/detail.html
@@ -69,11 +69,11 @@
 
         <form class="ui reply form" role="form" th:action="@{/disc/{id}/comments(id=${disc.id})}" method="post">
             <div class="field">
-                <textarea id="comment" name="comment" cols="40" rows="5"></textarea><br/>
+                <textarea id="comment" name="comment" cols="40" rows="5" required="required"></textarea><br/>
             </div>
             <div class="field">
                 <label th:text="#{detail.comment.rating}" for="rating">Bewertung</label>
-                <input id="rating" name="rating" type="number" value="5" />
+                <input id="rating" name="rating" type="number" value="5" required="required" />
             </div>
             <button type="submit" class="ui labeled icon button">
                 <i class="icon edit"></i><span th:text="#{detail.comment.addComment}"> Kommentieren</span>


### PR DESCRIPTION
By pressing the `add comment` button while having no comment written the page will end up in `Whitelabel Error Page`.
The same happens when setting the rating to anything like -1 or 500.
It would also be nice to have proper error handling (an `/error` page).