### PR TITLE
Fix out of sync javadoc method parameters

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,4 +32,4 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Build with Maven
-      run: mvn -B verify
+      run: ./mvnw -Pci -B verify

--- a/src/main/java/videoshop/customer/CustomerDataInitializer.java
+++ b/src/main/java/videoshop/customer/CustomerDataInitializer.java
@@ -50,7 +50,7 @@ class CustomerDataInitializer implements DataInitializer {
 	 * Creates a new {@link CustomerDataInitializer} with the given {@link UserAccountManagement} and
 	 * {@link CustomerRepository}.
 	 *
-	 * @param userAccountManager must not be {@literal null}.
+	 * @param userAccountManagement must not be {@literal null}.
 	 * @param customerManagement must not be {@literal null}.
 	 */
 	CustomerDataInitializer(UserAccountManagement userAccountManagement, CustomerManagement customerManagement) {

--- a/src/main/java/videoshop/order/OrderController.java
+++ b/src/main/java/videoshop/order/OrderController.java
@@ -56,7 +56,7 @@ class OrderController {
 	/**
 	 * Creates a new {@link OrderController} with the given {@link OrderManagement}.
 	 *
-	 * @param orderManager must not be {@literal null}.
+	 * @param orderManagement must not be {@literal null}.
 	 */
 	OrderController(OrderManagement<Order> orderManagement) {
 


### PR DESCRIPTION
Builds would fail with the `ci` Maven profile because of inconsistent javadoc parameter names. In addition to fixing this bug, this PR corrects the Actions workflow to use the `ci` Maven profile to detect such errors earlier.